### PR TITLE
Support 'gateway' option when creating network

### DIFF
--- a/pkg/plugin/dhcp_manager.go
+++ b/pkg/plugin/dhcp_manager.go
@@ -78,7 +78,7 @@ func (m *dhcpManager) renew(v6 bool, info udhcpc.Info) error {
 			Warn("udhcpc renew with changed IP")
 	}
 
-	if !v6 && info.Gateway != "" {
+	if !v6 && info.Gateway != "" && m.opts.Gateway == "" {
 		newGateway := net.ParseIP(info.Gateway)
 
 		routes, err := m.netHandle.RouteListFiltered(unix.AF_INET, &netlink.Route{

--- a/pkg/plugin/network.go
+++ b/pkg/plugin/network.go
@@ -238,7 +238,11 @@ func (p *Plugin) CreateEndpoint(ctx context.Context, r CreateEndpointRequest) (C
 			} else {
 				res.Interface.Address = info.IP
 				hint.IPv4 = ip
-				hint.Gateway = info.Gateway
+				if opts.Gateway != "" {
+					hint.Gateway = opts.Gateway
+				} else {
+					hint.Gateway = info.Gateway
+				}
 			}
 			p.joinHints[r.EndpointID] = hint
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -30,6 +30,7 @@ func IsDHCPPlugin(driver string) bool {
 // DHCPNetworkOptions contains options for the DHCP network driver
 type DHCPNetworkOptions struct {
 	Bridge          string
+	Gateway         string
 	IPv6            bool
 	LeaseTimeout    time.Duration `mapstructure:"lease_timeout"`
 	IgnoreConflicts bool          `mapstructure:"ignore_conflicts"`


### PR DESCRIPTION
When using docker to build an intermediate gateway (like raspberry pi), we may expect a following workflow:
* Set DHCP server's published default gateway to be intermediate gateway's LAN IP;
* Set intermediate gateway (the docker container)'s default gateway to be router's LAN IP.

However, currently `docker-net-dhcp` will always use DHCP published gateway when creating the container, and when that published IP is the same as container's lease IP, an error `Destination unreachable` will raise, preventing us to modify the gateway later after the container created.

Thus, this PR add a new option `gateway` when creating the docker network, to forcibly uses a user-provided gateway instead of one provided by DHCP when creating the container.

Usage example:
`docker create .... -o bridge=br-eth -o gateway=192.168.0.2`